### PR TITLE
fix(:tools): pdf `+lookup/dictionary-definition`

### DIFF
--- a/modules/tools/lookup/autoload/lookup.el
+++ b/modules/tools/lookup/autoload/lookup.el
@@ -410,6 +410,8 @@ Otherwise, falls back on `find-file-at-point'."
    (list (or (doom-thing-at-point-or-region 'word)
              (read-string "Look up in dictionary: "))
          current-prefix-arg))
+  (if (equal major-mode 'pdf-view-mode)
+      (setq identifier (car (pdf-view-active-region-text))))
   (message "Looking up dictionary definition for %S" identifier)
   (cond ((and IS-MAC (require 'osx-dictionary nil t))
          (osx-dictionary--view-result identifier))


### PR DESCRIPTION
Set the selected `identifier` to `pdf-view-active-region-text` in the case of being selected in pdf-view-mode.