### PR TITLE
fix(popup): cycle windows with no window property

### DIFF
--- a/modules/ui/popup/autoload/popup.el
+++ b/modules/ui/popup/autoload/popup.el
@@ -355,7 +355,8 @@ Any non-nil value besides the above will be used as the raw value for
                                    ;; parameter, since `other-window' won't.
                                    (window-parameter w 'no-other-window)))
                    (window-list)))
-      (select-window (if (+popup-window-p)
+      (select-window (if (or (+popup-window-p)
+                             (window-parameter nil 'no-other-window))
                          (let ((window (selected-window)))
                            (or (car-safe (cdr (memq window popups)))
                                (car (delq window popups))


### PR DESCRIPTION
Previously, +popup/other would do nothing if a window with the no-other-window property that was not a popup was focused. Now +popup/other will always select different window if there is another popup or window with the no-other-window property. This fixes #7119.